### PR TITLE
Remove constraint message being a string

### DIFF
--- a/nodes/pubnub-node-red.js
+++ b/nodes/pubnub-node-red.js
@@ -33,13 +33,8 @@ module.exports = function(RED) {
                 pn_obj.subscribe({
                     channel  : this.channel,
                     callback : function(message) {
-                        if (typeof message == 'string') {
-                            node.log("Received message payload is " + message);
-                            node.send({payload : message});
-                        }
-                        else {
-                            node.error("Received message is not a string!");
-                        }
+                        node.log("Received message payload is " + message);
+                        node.send({payload : message});
                     }
                 });
                 this.status({fill:"green",shape:"dot",text:"listening"});


### PR DESCRIPTION
I'm new to Node-RED, so I'm not sure if there is a particular reason that the message needs to be a string.

Though it might have helped me debug a bit if my js object had been visible in the debug node rather than the 'Received message is not a string' error.

---

Node-RED seems to handle objects okay:

![image](https://cloud.githubusercontent.com/assets/51385/5038642/ebaf7cd4-6b8a-11e4-9e1e-e92b9711001b.png)
