### PR TITLE
Enables a dynamic msg.channel for the publish function

### DIFF
--- a/nodes/pubnub-node-red.html
+++ b/nodes/pubnub-node-red.html
@@ -80,6 +80,8 @@
 
 <script type="text/x-red" data-help-name="pubnub out">
     <p>Publishes <b>msg.payload</b> to the PubNub channel specified by the edit window.</p>
+    <p>Messages will publish whatever your default channel(s) are (as defined in the config),
+    or you can pass it a dynamic <code>msg.channel</code> to publish to instead.
     <p>The <code>msg.payload</code> input may be a string or a JSON object</p>
 </script>
 

--- a/nodes/pubnub-node-red.js
+++ b/nodes/pubnub-node-red.js
@@ -117,24 +117,24 @@ module.exports = function (RED) {
 
     // Publish to a channel
     if (this.pn_obj != null) {
-      if (this.channel) {
         node = this;
         this.on('input', function (msg) {
-          this.log('Publishing to channel ' + node.channel);
-
-          node.pn_obj.publish({ channel: node.channel, message: msg.payload }, function (status, response) {
-            if (status.error) {
-              node.log('Failure sending message ' + msg.payload + ' ' + JSON.stringify(status, null, '\t') + 'Please retry publish!');
-            } else {
-              node.log('Success sending message ' + msg.payload + ' ' + JSON.stringify(response, null, '\t'));
-            }
-          });
+          var _channel = (msg.channel) ? msg.channel : node.channel;
+          if (_channel) {
+            this.log('Publishing to channel ' + _channel);
+            node.pn_obj.publish({ channel: _channel, message: msg.payload }, function (status, response) {
+              if (status.error) {
+                node.warn('Failure sending message ' + msg.payload + ' ' + JSON.stringify(status, null, '\t') + 'Please retry publish!');
+              } else {
+                node.log('Success sending message ' + msg.payload + ' ' + JSON.stringify(response, null, '\t'));
+              }
+            });
+            this.status({ fill: 'green', shape: 'dot', text: 'published' });
+          } else {
+            this.warn('Unknown channel name!');
+            this.status({ fill: 'green', shape: 'ring', text: 'channel?' });
+          }
         });
-        this.status({ fill: 'green', shape: 'dot', text: 'published' });
-      } else {
-        this.warn('Unknown channel name!');
-        this.status({ fill: 'green', shape: 'ring', text: 'channel?' });
-      }
     }
 
     // Destroy on node close event

--- a/nodes/pubnub-node-red.js
+++ b/nodes/pubnub-node-red.js
@@ -117,24 +117,24 @@ module.exports = function (RED) {
 
     // Publish to a channel
     if (this.pn_obj != null) {
-        node = this;
-        this.on('input', function (msg) {
-          var _channel = (msg.channel) ? msg.channel : node.channel;
-          if (_channel) {
-            this.log('Publishing to channel ' + _channel);
-            node.pn_obj.publish({ channel: _channel, message: msg.payload }, function (status, response) {
-              if (status.error) {
-                node.warn('Failure sending message ' + msg.payload + ' ' + JSON.stringify(status, null, '\t') + 'Please retry publish!');
-              } else {
-                node.log('Success sending message ' + msg.payload + ' ' + JSON.stringify(response, null, '\t'));
-              }
-            });
-            this.status({ fill: 'green', shape: 'dot', text: 'published' });
-          } else {
-            this.warn('Unknown channel name!');
-            this.status({ fill: 'green', shape: 'ring', text: 'channel?' });
-          }
-        });
+      node = this;
+      this.on('input', function (msg) {
+        var outChannel = (msg.channel) ? msg.channel : node.channel;
+        if (outChannel) {
+          this.log('Publishing to channel ' + outChannel);
+          node.pn_obj.publish({ channel: outChannel, message: msg.payload }, function (status, response) {
+            if (status.error) {
+              node.warn('Failure sending message ' + msg.payload + ' ' + JSON.stringify(status, null, '\t') + 'Please retry publish!');
+            } else {
+              node.log('Success sending message ' + msg.payload + ' ' + JSON.stringify(response, null, '\t'));
+            }
+          });
+          this.status({ fill: 'green', shape: 'dot', text: 'published' });
+        } else {
+          this.warn('Unknown channel name!');
+          this.status({ fill: 'green', shape: 'ring', text: 'channel?' });
+        }
+      });
     }
 
     // Destroy on node close event


### PR DESCRIPTION
# Static destinations are so [booooooring](https://media.giphy.com/media/XuDlhFtiWXZEk/giphy.gif).

Your outbound messages want **options**! Exciting **destinations**! A **choose-your-own-adventure** story! 

Define glorious new and unique channels _dynamically_ with `msg.channel` for your PubNub output nodes. Revel in the excitement from generating a message that knows it can go to fabulous locations that no other message will ever see.

Your messages want to be all [woooooo!](https://media.giphy.com/media/3ohhwGpIOhPtQ5kALu/giphy.gif)

Why not give them a little excitement before they die? 🎉 

